### PR TITLE
Using annotations and reflection to auto discover the parser validators.

### DIFF
--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -129,6 +129,12 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <reporting>
         <plugins>

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/BluecoatValidation.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/BluecoatValidation.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+@ValidationHandler(parser="bluecoat")
+public class BluecoatValidation extends SampleDataValidation {
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/BroValidation.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/BroValidation.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+@ValidationHandler(parser="bro")
+public class BroValidation extends SampleDataValidation {
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/SnortValidation.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/SnortValidation.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+@ValidationHandler(parser="snort")
+public class SnortValidation extends SampleDataValidation{
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/SquidValidation.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/SquidValidation.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+@ValidationHandler(parser="squid")
+public class SquidValidation extends SampleDataValidation {
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/ValidationHandler.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/ValidationHandler.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+public @interface ValidationHandler {
+  String parser();
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/YafValidation.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/validation/YafValidation.java
@@ -1,0 +1,5 @@
+package org.apache.metron.parsers.integration.validation;
+
+@ValidationHandler(parser="yaf")
+public class YafValidation extends SampleDataValidation {
+}


### PR DESCRIPTION
This is the approach that I was suggesting earlier.  Let me know if you think this is better.  The main benefit, as I see it, is that you don't have to edit the Integration Test, just add a class with an annotation and it will automatically pull it in.