### PR TITLE
 Bug Fixes

### DIFF
--- a/metron-interface/metron-config/src/app/_variables.scss
+++ b/metron-interface/metron-config/src/app/_variables.scss
@@ -50,6 +50,8 @@ $dialog-2x-width: 640px;
 $dialog-4x-width: 1380px;
 $slider-left-padding: 25px;
 
+$button-bar-height: 70px;
+
 @mixin transform($transforms) {
   -moz-transform: $transforms;
   -o-transform: $transforms;

--- a/metron-interface/metron-config/src/app/model/sensor-parser-config-history.ts
+++ b/metron-interface/metron-config/src/app/model/sensor-parser-config-history.ts
@@ -22,4 +22,8 @@ export class SensorParserConfigHistory {
   createdDate: string;
   modifiedByDate: string;
   config: SensorParserConfig;
+
+  constructor() {
+    this.config = new SensorParserConfig();
+  }
 }

--- a/metron-interface/metron-config/src/app/sensors/sensor-field-schema/sensor-field-schema.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-field-schema/sensor-field-schema.component.ts
@@ -279,7 +279,7 @@ export class SensorFieldSchemaComponent implements OnInit, OnChanges {
     let sensorTopicUpperCase = this.sensorParserConfig.sensorTopic.toUpperCase();
     let parseMessageRequest = new ParseMessageRequest();
     parseMessageRequest.sensorParserConfig = JSON.parse(JSON.stringify(this.sensorParserConfig));
-    parseMessageRequest.grokStatement = sensorTopicUpperCase + ' ' +  this.grokStatement;
+    parseMessageRequest.grokStatement = this.grokStatement;
     parseMessageRequest.sampleData = sampleData;
 
     if (parseMessageRequest.sensorParserConfig.parserConfig['patternLabel'] == null) {

--- a/metron-interface/metron-config/src/app/sensors/sensor-grok/sensor-grok.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-grok/sensor-grok.component.ts
@@ -65,7 +65,7 @@ export class SensorGrokComponent implements OnInit, OnChanges {
   onTestGrokStatement() {
     this.parsedMessage = {};
 
-    if (this.newGrokStatement.length === 0) {
+    if(this.newGrokStatement.indexOf('%{') == -1) {
       return;
     }
 

--- a/metron-interface/metron-config/src/app/sensors/sensor-grok/sensor-grok.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-grok/sensor-grok.component.ts
@@ -65,7 +65,7 @@ export class SensorGrokComponent implements OnInit, OnChanges {
   onTestGrokStatement() {
     this.parsedMessage = {};
 
-    if(this.newGrokStatement.indexOf('%{') == -1) {
+    if (this.newGrokStatement.indexOf('%{') === -1) {
       return;
     }
 

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.html
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.html
@@ -47,7 +47,7 @@
               <div class="col-xs-12 form-sub-title">Grok Statement</div>
               <div id="collapseGrok" class="col-xs-12  pull-left form-value panel-collapse collapse"></div>
               <div class="col-xs-12  pull-left form-value grok" [innerHtml]="grokStatement"></div>
-              <a class="collapsed blue-label font-weight-bold col-xs-8 col-xs-push-4" data-toggle="collapse" href="#collapseGrok" aria-expanded="false" aria-controls="collapseGrok"  #grokLink (click)="grokLink.text=(grokLink.text==='show more')?'show less':'show more'">show more</a>
+              <a *ngIf="grokStatement.length>0" class="collapsed blue-label font-weight-bold col-xs-8 col-xs-push-4" data-toggle="collapse" href="#collapseGrok" aria-expanded="false" aria-controls="collapseGrok"  #grokLink (click)="grokLink.text=(grokLink.text==='show more')?'show less':'show more'">show more</a>
               <div class="px-1"> <div class="col-xs-12 form-seperator"></div> </div>
             </div>
 

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.html
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.html
@@ -16,7 +16,7 @@
 <metron-config-metron-modal [backgroundMasked]="false">
 
     <div class="metron-slider-pane fill load-right-to-left dialog1x">
-      <div>
+      <div class="metron-readonly-pane">
       <div class="row">
         <div class="col-xs-12 form-title">{{selectedSensorName}}
           <i class="fa fa-times pull-right close-button" aria-hidden="true" (click)="goBack()"></i>
@@ -42,13 +42,15 @@
             <div *ngIf="item.model == 'sensorParserConfigHistory'" class="col-xs-6  px-0 pull-left form-value">{{ sensorParserConfigHistory[item.value] ? sensorParserConfigHistory[item.value] : "-" }}</div>
             <div *ngIf="item.model == 'kafkaTopic'" class="col-xs-6  px-0 pull-left form-value">{{ kafkaTopic[item.value] ? kafkaTopic[item.value] : "-" }}</div>
             <div *ngIf="item.model == 'topologyStatus'" class="col-xs-6  px-0  pull-left form-value">{{ topologyStatus[item.value] ? topologyStatus[item.value] : "-" }}</div>
-            <div *ngIf="item.model == 'grokStatement' && sensorParserConfigHistory['parserName'] === 'Grok'" style="border: none">
+
+            <div *ngIf="item.model == 'grokStatement' && sensorParserConfigHistory.config.parserClassName === 'org.apache.metron.parsers.GrokParser'" style="border: none">
               <div class="col-xs-12 form-sub-title">Grok Statement</div>
               <div id="collapseGrok" class="col-xs-12  pull-left form-value panel-collapse collapse"></div>
               <div class="col-xs-12  pull-left form-value grok" [innerHtml]="grokStatement"></div>
-              <a *ngIf="grokStatement.length>0" class="collapsed blue-label font-weight-bold col-xs-8 col-xs-push-4" data-toggle="collapse" href="#collapseGrok" aria-expanded="false" aria-controls="collapseGrok"  #grokLink (click)="grokLink.text=(grokLink.text==='show more')?'show less':'show more'">show more</a>
+              <a class="collapsed blue-label font-weight-bold col-xs-8 col-xs-push-4" data-toggle="collapse" href="#collapseGrok" aria-expanded="false" aria-controls="collapseGrok"  #grokLink (click)="grokLink.text=(grokLink.text==='show more')?'show less':'show more'">show more</a>
               <div class="px-1"> <div class="col-xs-12 form-seperator"></div> </div>
             </div>
+
             <div *ngIf="item.model == 'transforms'">
 
               <div id="collapseTransform" class="col-xs-12  pull-left form-value panel-collapse collapse">

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.scss
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.scss
@@ -18,6 +18,10 @@
 @import "../../_variables.scss";
 @import "../../../styles.scss";
 
+.metron-readonly-pane {
+  margin-bottom: $button-bar-height + 10px;
+}
+
 .metron-button-bar
 {
   background: $gray-light;

--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.ts
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-config-readonly/sensor-parser-config-readonly.component.ts
@@ -102,11 +102,12 @@ export class SensorParserConfigReadonlyComponent implements OnInit {
     this.sensorParserConfigHistoryService.get(this.selectedSensorName).subscribe(
       (results: SensorParserConfigHistory) => {
         this.sensorParserConfigHistory = results;
-
-        this.sensorParserConfigHistory['parserClassName'] =
-            this.sensorParserConfigHistory.config.parserClassName.replace('org.apache.metron.parsers.', '');
         this.setGrokStatement();
         this.setTransformsConfigKeys();
+
+        let items = this.sensorParserConfigHistory.config.parserClassName.split('.');
+        this.sensorParserConfigHistory['parserClassName'] = items[items.length - 1].replace('Basic', '').replace('Parser', '');
+
       });
   }
 

--- a/metron-interface/metron-config/src/styles.scss
+++ b/metron-interface/metron-config/src/styles.scss
@@ -712,7 +712,7 @@ button
   border-top: solid 2px $edit-background-border;
   border-right: solid 1px $edit-background-border;
   border-left: solid 1px $edit-background-border;
-  max-height: 70px;
+  max-height: $button-bar-height;
 }
 
 .tooltip


### PR DESCRIPTION
Sensor Details pane
    -does not show Grok Configuration
    -'show more' button for Threat Triage Rules is hidden
    -Parser name is displayed differently compared to list page
Sensor Field Schema is broke as parseMessage function fails to parse the grok message
Sensor Grok Pane shows an error message when we open the pane to add a new parser