### PR TITLE
Migrate to a DAO implementation

### DIFF
--- a/dependencies_with_url.csv
+++ b/dependencies_with_url.csv
@@ -116,9 +116,6 @@ com.fasterxml.jackson.core:jackson-databind:jar:2.8.3:compile,ASLv2,http://githu
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.6.6:compile,ASLv2,http://wiki.fasterxml.com/JacksonForCbor
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.6.6:compile,ASLv2,http://wiki.fasterxml.com/JacksonForSmile
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.6.6:compile,ASLv2,https://github.com/FasterXML/jackson
-com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.8.3:compile,ASLv2,http://wiki.fasterxml.com/JacksonForCbor
-com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.8.3:compile,ASLv2,http://wiki.fasterxml.com/JacksonForSmile
-com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.8.3:compile,ASLv2,https://github.com/FasterXML/jackson
 com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.8.1:compile,ASLv2,https://github.com/FasterXML/jackson-datatype-joda
 com.fasterxml:classmate:jar:1.3.1:compile,ASLv2,http://github.com/cowtowncoder/java-classmate
 com.google.code.gson:gson:jar:2.2.4:compile,The Apache Software License, Version 2.0,http://code.google.com/p/google-gson/

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -173,24 +173,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.metron</groupId>
-            <artifactId>elasticsearch-shaded</artifactId>
-            <version>${project.parent.version}</version>
-            <exclusions>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.metron</groupId>
-            <artifactId>metron-elasticsearch</artifactId>
-            <version>${project.parent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>${swagger.version}</version>
@@ -257,13 +239,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.metron</groupId>
-            <artifactId>metron-elasticsearch</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${global_kafka_version}</version>
@@ -282,18 +257,27 @@
             <version>1.7</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-indexing</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-indexing</artifactId>
+            <version>${parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>${global_reflections_version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
         <dependencies>
-            <!-- Spring Boot brings in an Elasticsearch dependency so we need to ensure the Metron's version is used -->
-            <dependency>
-                <groupId>org.elasticsearch</groupId>
-                <artifactId>elasticsearch</artifactId>
-                <version>${global_elasticsearch_version}</version>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
@@ -58,4 +58,5 @@ public class MetronRestConstants {
   public static final String KERBEROS_KEYTAB_SPRING_PROPERTY = "kerberos.keytab";
 
   public static final String SEARCH_MAX_RESULTS = "search.max.results";
+  public static final String INDEX_DAO_IMPL = "index.dao.impl";
 }

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/SearchController.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/controller/SearchController.java
@@ -20,8 +20,8 @@ package org.apache.metron.rest.controller;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import org.apache.metron.rest.RestException;
-import org.apache.metron.rest.model.SearchRequest;
-import org.apache.metron.rest.model.SearchResponse;
+import org.apache.metron.indexing.dao.search.SearchRequest;
+import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.rest.service.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -30,9 +30,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/search")

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/IndexDaoSearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/IndexDaoSearchServiceImpl.java
@@ -1,0 +1,33 @@
+package org.apache.metron.rest.service.impl;
+
+import org.apache.metron.common.system.Environment;
+import org.apache.metron.indexing.dao.IndexDao;
+import org.apache.metron.indexing.dao.search.InvalidSearchException;
+import org.apache.metron.indexing.dao.search.SearchRequest;
+import org.apache.metron.indexing.dao.search.SearchResponse;
+import org.apache.metron.rest.MetronRestConstants;
+import org.apache.metron.rest.RestException;
+import org.apache.metron.rest.service.GlobalConfigService;
+import org.apache.metron.rest.service.SearchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IndexDaoSearchServiceImpl implements SearchService {
+  private IndexDao dao;
+
+  @Autowired
+  public IndexDaoSearchServiceImpl(IndexDao dao) {
+    this.dao = dao;
+  }
+
+  @Override
+  public SearchResponse search(SearchRequest searchRequest) throws RestException {
+    try {
+      return dao.search(searchRequest);
+    }
+    catch(InvalidSearchException ise) {
+      throw new RestException(ise.getMessage(), ise);
+    }
+  }
+}

--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/IndexDaoSearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/IndexDaoSearchServiceImpl.java
@@ -1,13 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.rest.service.impl;
 
-import org.apache.metron.common.system.Environment;
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.search.InvalidSearchException;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
-import org.apache.metron.rest.MetronRestConstants;
 import org.apache.metron.rest.RestException;
-import org.apache.metron.rest.service.GlobalConfigService;
 import org.apache.metron.rest.service.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/metron-interface/metron-rest/src/main/resources/application-test.yml
+++ b/metron-interface/metron-rest/src/main/resources/application-test.yml
@@ -44,3 +44,6 @@ storm:
 search:
   max:
     results: 100
+index:
+  dao:
+     impl: org.apache.metron.indexing.dao.InMemoryDao

--- a/metron-interface/metron-rest/src/main/resources/application.yml
+++ b/metron-interface/metron-rest/src/main/resources/application.yml
@@ -44,3 +44,7 @@ curator:
 search:
   max:
     results: 1000
+
+index:
+  dao:
+     impl: org.apache.metron.elasticsearch.dao.ElasticsearchDao

--- a/metron-interface/metron-rest/src/main/scripts/metron-rest
+++ b/metron-interface/metron-rest/src/main/scripts/metron-rest
@@ -58,6 +58,11 @@ fi
 if [ $METRON_JDBC_CLIENT_PATH ]; then
     METRON_JVMFLAGS+=" -Dloader.path=$METRON_JDBC_CLIENT_PATH"
 fi
+if [ $METRON_INDEX_CP ]; then
+    METRON_JVMFLAGS+=" -cp $METRON_INDEX_CP"
+else
+    METRON_JVMFLAGS+=" -cp $METRON_HOME/lib/metron-elasticsearch-$METRON_VERSION-uber.jar"
+fi
 DAEMON="java $METRON_JVMFLAGS -jar $METRON_HOME/lib/metron-rest-$METRON_VERSION.jar $METRON_SPRING_OPTIONS"
 
 #

--- a/metron-platform/elasticsearch-shaded/pom.xml
+++ b/metron-platform/elasticsearch-shaded/pom.xml
@@ -33,6 +33,44 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${global_elasticsearch_version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-smile</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${global_jackson_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+            <version>${global_jackson_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${global_jackson_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>${global_jackson_version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -55,10 +93,6 @@
                                 <relocation>
                                     <pattern>com.google.common</pattern>
                                     <shadedPattern>org.apache.metron.guava.elasticsearch-shaded</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.fasterxml.jackson.core</pattern>
-                                    <shadedPattern>org.apache.metron.com.fasterxml.jackson.core.elasticsearch-shaded</shadedPattern>
                                 </relocation>
                             </relocations>
                             <artifactSet>

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/ReflectionUtils.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/ReflectionUtils.java
@@ -19,7 +19,7 @@ package org.apache.metron.common.utils;
 
 import java.lang.reflect.InvocationTargetException;
 
-public class ReflectionUtils<T> {
+public class ReflectionUtils {
 
   public static <T> T createInstance(String className, T defaultClass) {
     T instance;

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -29,11 +29,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${global_hbase_guava_version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.metron</groupId>
             <artifactId>elasticsearch-shaded</artifactId>
             <version>${project.parent.version}</version>

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchDaoIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchDaoIntegrationTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.elasticsearch.integration;
+
+
+import org.apache.metron.elasticsearch.dao.ElasticsearchDao;
+import org.apache.metron.elasticsearch.integration.components.ElasticSearchComponent;
+import org.apache.metron.indexing.dao.AccessConfig;
+import org.apache.metron.indexing.dao.IndexDao;
+import org.apache.metron.indexing.dao.IndexingDaoIntegrationTest;
+import org.apache.metron.integration.InMemoryComponent;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.util.HashMap;
+
+public class ElasticsearchDaoIntegrationTest extends IndexingDaoIntegrationTest {
+  private static String indexDir = "target/elasticsearch_search";
+  private static String dateFormat = "yyyy.MM.dd.HH";
+
+
+  @Override
+  protected IndexDao createDao() throws Exception {
+    IndexDao ret = new ElasticsearchDao();
+    ret.init(
+            new HashMap<String, Object>() {{
+              put("es.clustername", "metron");
+              put("es.port", "9300");
+              put("es.ip", "localhost");
+              put("es.date.format", dateFormat);
+            }},
+            new AccessConfig() {{
+              setMaxSearchResults(100);
+            }}
+    );
+    return ret;
+  }
+
+  @Override
+  protected InMemoryComponent startIndex() throws Exception {
+    InMemoryComponent es = new ElasticSearchComponent.Builder()
+            .withHttpPort(9211)
+            .withIndexDir(new File(indexDir))
+            .build();
+    es.start();
+    return es;
+  }
+
+  @Override
+  protected void loadTestData() throws ParseException {
+    ElasticSearchComponent es = (ElasticSearchComponent)indexComponent;
+    BulkRequestBuilder bulkRequest = es.getClient().prepareBulk().setRefresh(true);
+    JSONArray broArray = (JSONArray) new JSONParser().parse(broData);
+    for(Object o: broArray) {
+      JSONObject jsonObject = (JSONObject) o;
+      IndexRequestBuilder indexRequestBuilder = es.getClient().prepareIndex("bro_index_2017.01.01.01", "bro_doc");
+      indexRequestBuilder = indexRequestBuilder.setSource(jsonObject.toJSONString());
+      indexRequestBuilder = indexRequestBuilder.setTimestamp(jsonObject.get("timestamp").toString());
+      bulkRequest.add(indexRequestBuilder);
+    }
+    JSONArray snortArray = (JSONArray) new JSONParser().parse(snortData);
+    for(Object o: snortArray) {
+      JSONObject jsonObject = (JSONObject) o;
+      IndexRequestBuilder indexRequestBuilder = es.getClient().prepareIndex("snort_index_2017.01.01.02", "snort_doc");
+      indexRequestBuilder = indexRequestBuilder.setSource(jsonObject.toJSONString());
+      indexRequestBuilder = indexRequestBuilder.setTimestamp(jsonObject.get("timestamp").toString());
+      bulkRequest.add(indexRequestBuilder);
+    }
+    BulkResponse bulkResponse = bulkRequest.execute().actionGet();
+    if (bulkResponse.hasFailures()) {
+      throw new RuntimeException("Failed to index test data");
+    }
+  }
+}

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/matcher/SearchRequestMatcher.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/matcher/SearchRequestMatcher.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.matcher;
+package org.apache.metron.elasticsearch.matcher;
 
-import org.apache.metron.rest.model.SortField;
+import org.apache.metron.indexing.dao.search.SortField;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -44,7 +44,7 @@ public class SearchRequestMatcher extends ArgumentMatcher<SearchRequest> {
             .trackScores(true);
     for(SortField sortField: sortFields) {
       FieldSortBuilder fieldSortBuilder = new FieldSortBuilder(sortField.getField());
-      fieldSortBuilder.order(sortField.getSortOrder() == org.apache.metron.rest.model.SortOrder.DESC ? SortOrder.DESC : SortOrder.ASC);
+      fieldSortBuilder.order(sortField.getSortOrder() == org.apache.metron.indexing.dao.search.SortOrder.DESC ? SortOrder.DESC : SortOrder.ASC);
       searchSourceBuilder = searchSourceBuilder.sort(fieldSortBuilder);
     }
     expectedSource = searchSourceBuilder.buildAsBytes(Requests.CONTENT_TYPE);

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
@@ -1,0 +1,25 @@
+package org.apache.metron.indexing.dao;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AccessConfig {
+  private Integer maxSearchResults;
+  private Map<String, String> optionalSettings = new HashMap<>();
+
+  public Integer getMaxSearchResults() {
+    return maxSearchResults;
+  }
+
+  public void setMaxSearchResults(Integer maxSearchResults) {
+    this.maxSearchResults = maxSearchResults;
+  }
+
+  public Map<String, String> getOptionalSettings() {
+    return optionalSettings;
+  }
+
+  public void setOptionalSettings(Map<String, String> optionalSettings) {
+    this.optionalSettings = optionalSettings;
+  }
+}

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.indexing.dao;
 
 import java.util.HashMap;

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDao.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDao.java
@@ -15,37 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.model;
+package org.apache.metron.indexing.dao;
+
+import org.apache.metron.indexing.dao.search.InvalidSearchException;
+import org.apache.metron.indexing.dao.search.SearchRequest;
+import org.apache.metron.indexing.dao.search.SearchResponse;
 
 import java.util.Map;
 
-public class SearchResult {
-
-  private String id;
-  private Map<String, Object> source;
-  private float score;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Map<String, Object> getSource() {
-    return source;
-  }
-
-  public void setSource(Map<String, Object> source) {
-    this.source = source;
-  }
-
-  public float getScore() {
-    return score;
-  }
-
-  public void setScore(float score) {
-    this.score = score;
-  }
+public interface IndexDao {
+  SearchResponse search(SearchRequest searchRequest) throws InvalidSearchException;
+  void init(Map<String, Object> globalConfig, AccessConfig config);
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDaoFactory.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDaoFactory.java
@@ -1,0 +1,13 @@
+package org.apache.metron.indexing.dao;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+public class IndexDaoFactory {
+  public static IndexDao create(String daoImpl, Map<String, Object> globalConfig, AccessConfig config) throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    Class<? extends IndexDao> clazz = (Class<? extends IndexDao>) Class.forName(daoImpl);
+    IndexDao instance = clazz.getConstructor().newInstance();
+    instance.init(globalConfig, config);
+    return instance;
+  }
+}

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDaoFactory.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/IndexDaoFactory.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.indexing.dao;
 
 import java.lang.reflect.InvocationTargetException;

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/InvalidSearchException.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/InvalidSearchException.java
@@ -15,23 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.model;
+package org.apache.metron.indexing.dao.search;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public enum SortOrder {
-  @JsonProperty("desc")
-  DESC("desc"),
-  @JsonProperty("asc")
-  ASC("asc");
-
-  private String sortOrder;
-
-  SortOrder(String sortOrder) {
-    this.sortOrder = sortOrder;
+public class InvalidSearchException extends Exception {
+  public InvalidSearchException(String message) {
+    super(message);
   }
-
-  public String getSortOrder() {
-    return sortOrder;
+  public InvalidSearchException(String message, Throwable t) {
+    super(message, t);
   }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchRequest.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchRequest.java
@@ -15,10 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.model;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+package org.apache.metron.indexing.dao.search;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +31,7 @@ public class SearchRequest {
   public SearchRequest() {
     SortField defaultSortField = new SortField();
     defaultSortField.setField("timestamp");
-    defaultSortField.setSortOrder(SortOrder.DESC);
+    defaultSortField.setSortOrder(SortOrder.DESC.toString());
     sort = new ArrayList<>();
     sort.add(defaultSortField);
   }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchResponse.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchResponse.java
@@ -15,25 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.model;
+package org.apache.metron.indexing.dao.search;
 
-public class SortField {
-  private String field;
-  private SortOrder sortOrder;
+import java.util.ArrayList;
+import java.util.List;
 
-  public String getField() {
-    return field;
+public class SearchResponse {
+
+  private long total;
+  private List<SearchResult> results = new ArrayList<>();
+
+  public long getTotal() {
+    return total;
   }
 
-  public void setField(String field) {
-    this.field = field;
+  public void setTotal(long total) {
+    this.total = total;
   }
 
-  public SortOrder getSortOrder() {
-    return sortOrder;
+  public List<SearchResult> getResults() {
+    return results;
   }
 
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
+  public void setResults(List<SearchResult> results) {
+    this.results = results;
   }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchResult.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SearchResult.java
@@ -15,14 +15,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.service;
+package org.apache.metron.indexing.dao.search;
 
-import org.apache.metron.rest.RestException;
-import org.apache.metron.indexing.dao.search.SearchRequest;
-import org.apache.metron.indexing.dao.search.SearchResponse;
+import java.util.Map;
 
-public interface SearchService {
+public class SearchResult {
 
-  SearchResponse search(SearchRequest searchRequest) throws RestException;
+  private String id;
+  private Map<String, Object> source;
+  private float score;
 
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Map<String, Object> getSource() {
+    return source;
+  }
+
+  public void setSource(Map<String, Object> source) {
+    this.source = source;
+  }
+
+  public float getScore() {
+    return score;
+  }
+
+  public void setScore(float score) {
+    this.score = score;
+  }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SortField.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SortField.java
@@ -15,29 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.model;
+package org.apache.metron.indexing.dao.search;
 
-import java.util.ArrayList;
-import java.util.List;
+public class SortField {
+  private String field;
+  private SortOrder sortOrder;
 
-public class SearchResponse {
-
-  private long total;
-  private List<SearchResult> results = new ArrayList<>();
-
-  public long getTotal() {
-    return total;
+  public String getField() {
+    return field;
   }
 
-  public void setTotal(long total) {
-    this.total = total;
+  public void setField(String field) {
+    this.field = field;
   }
 
-  public List<SearchResult> getResults() {
-    return results;
+  public SortOrder getSortOrder() {
+    return sortOrder;
   }
 
-  public void setResults(List<SearchResult> results) {
-    this.results = results;
+  public void setSortOrder(String sortOrder) {
+    this.sortOrder = SortOrder.fromString(sortOrder);
   }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SortOrder.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/search/SortOrder.java
@@ -15,14 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.rest.service;
+package org.apache.metron.indexing.dao.search;
 
-import org.apache.metron.rest.RestException;
-import org.apache.metron.indexing.dao.search.SearchRequest;
-import org.apache.metron.indexing.dao.search.SearchResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public interface SearchService {
+public enum SortOrder {
+  @JsonProperty("desc")
+  DESC("desc"),
+  @JsonProperty("asc")
+  ASC("asc");
 
-  SearchResponse search(SearchRequest searchRequest) throws RestException;
+  private String sortOrder;
 
+  SortOrder(String sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public static SortOrder fromString(String order) {
+    return SortOrder.valueOf(order.toUpperCase());
+  }
 }

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/dao/InMemoryDao.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/dao/InMemoryDao.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.indexing.dao;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Iterables;
+import org.apache.metron.common.Constants;
+import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.indexing.dao.search.*;
+
+import java.io.IOException;
+import java.util.*;
+
+public class InMemoryDao implements IndexDao {
+  public static Map<String, List<String>> BACKING_STORE = new HashMap<>();
+  private AccessConfig config;
+
+  @Override
+  public SearchResponse search(SearchRequest searchRequest) throws InvalidSearchException {
+    if(config.getMaxSearchResults() != null && searchRequest.getSize() > config.getMaxSearchResults()) {
+      throw new InvalidSearchException("Search result size must be less than " + config.getMaxSearchResults());
+    }
+    List<SearchResult> response = new ArrayList<>();
+    for(String index : searchRequest.getIndices()) {
+      String i = null;
+      for(String storedIdx : BACKING_STORE.keySet()) {
+        if(storedIdx.equals(index) || storedIdx.startsWith(index + "_")) {
+          i = storedIdx;
+        }
+      }
+      if(i == null) {
+        continue;
+      }
+      for (String doc : BACKING_STORE.get(i)) {
+        Map<String, Object> docParsed = parse(doc);
+        if (isMatch(searchRequest.getQuery(), docParsed)) {
+          SearchResult result = new SearchResult();
+          result.setSource(docParsed);
+          result.setScore((float) Math.random());
+          result.setId(docParsed.getOrDefault(Constants.GUID, UUID.randomUUID()).toString());
+          response.add(result);
+        }
+      }
+    }
+
+    if(searchRequest.getSort().size() != 0) {
+      Collections.sort(response, sorted(searchRequest.getSort()));
+    }
+    SearchResponse ret = new SearchResponse();
+    List<SearchResult> finalResp = new ArrayList<>();
+    int maxSize = config.getMaxSearchResults() == null?searchRequest.getSize():config.getMaxSearchResults();
+    for(int i = searchRequest.getFrom();i < response.size()&& finalResp.size() <= maxSize;++i) {
+      finalResp.add(response.get(i));
+    }
+    ret.setTotal(response.size());
+    ret.setResults(finalResp);
+    return ret;
+  }
+
+
+  private static class ComparableComparator implements Comparator<Comparable>  {
+    SortOrder order = null;
+    public ComparableComparator(SortOrder order) {
+      this.order = order;
+    }
+    @Override
+    public int compare(Comparable o1, Comparable o2) {
+      int result = ComparisonChain.start().compare(o1, o2).result();
+      return order == SortOrder.ASC?result:-1*result;
+    }
+  }
+
+  private static Comparator<SearchResult> sorted(final List<SortField> fields) {
+    return (o1, o2) -> {
+      ComparisonChain chain = ComparisonChain.start();
+      for(SortField field : fields) {
+        Comparable f1 = (Comparable) o1.getSource().get(field.getField());
+        Comparable f2 = (Comparable) o2.getSource().get(field.getField());
+        chain = chain.compare(f1, f2, new ComparableComparator(field.getSortOrder()));
+      }
+      return chain.result();
+    };
+  }
+
+  private static boolean isMatch(String query, Map<String, Object> doc) {
+    if(query.equals("*")) {
+      return true;
+    }
+    if(query.contains(":")) {
+      Iterable<String> splits = Splitter.on(":").split(query.trim());
+      String field = Iterables.getFirst(splits, "");
+      String val = Iterables.getLast(splits, "");
+      Object o = doc.get(field);
+      if(o == null) {
+        return false;
+      }
+      else {
+        return o.equals(val);
+      }
+    }
+    return false;
+  }
+
+  private static Map<String, Object> parse(String doc) {
+    try {
+      return JSONUtils.INSTANCE.load(doc, new TypeReference<Map<String, Object>>() {});
+    } catch (IOException e) {
+      throw new IllegalStateException(e.getMessage(), e);
+    }
+
+  }
+
+  @Override
+  public void init(Map<String, Object> globalConfig, AccessConfig config) {
+    this.config = config;
+  }
+
+  public static void load(Map<String, List<String>> backingStore) {
+    BACKING_STORE = backingStore;
+  }
+
+  public static void clear() {
+    BACKING_STORE.clear();
+  }
+}

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/dao/IndexingDaoIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/dao/IndexingDaoIntegrationTest.java
@@ -1,0 +1,255 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.indexing.dao;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.indexing.dao.search.InvalidSearchException;
+import org.apache.metron.indexing.dao.search.SearchRequest;
+import org.apache.metron.indexing.dao.search.SearchResponse;
+import org.apache.metron.indexing.dao.search.SearchResult;
+import org.apache.metron.integration.InMemoryComponent;
+import org.json.simple.parser.ParseException;
+import org.junit.*;
+
+import java.util.List;
+
+public abstract class IndexingDaoIntegrationTest {
+  /**
+   * [
+   * {"source:type": "bro", "ip_src_addr":"192.168.1.1", "ip_src_port": 8010, "timestamp":1, "rejected":true},
+   * {"source:type": "bro" "ip_src_addr":"192.168.1.2", "ip_src_port": 8009, "timestamp":2, "rejected":false},
+   * {"source:type": "bro" "ip_src_addr":"192.168.1.3", "ip_src_port": 8008, "timestamp":3, "rejected":true},
+   * {"source:type": "bro" "ip_src_addr":"192.168.1.4", "ip_src_port": 8007, "timestamp":4, "rejected":false},
+   * {"source:type": "bro" "ip_src_addr":"192.168.1.5", "ip_src_port": 8006, "timestamp":5, "rejected":true}
+   * ]
+   */
+  @Multiline
+  public static String broData;
+
+  /**
+   * [
+   * {"source:type": "snort" "ip_src_addr":"192.168.1.6", "ip_src_port": 8005, "timestamp":6, "is_alert":false},
+   * {"source:type": "snort" "ip_src_addr":"192.168.1.1", "ip_src_port": 8004, "timestamp":7, "is_alert":true},
+   * {"source:type": "snort" "ip_src_addr":"192.168.1.7", "ip_src_port": 8003, "timestamp":8, "is_alert":false},
+   * {"source:type": "snort" "ip_src_addr":"192.168.1.1", "ip_src_port": 8002, "timestamp":9, "is_alert":true},
+   * {"source:type": "snort" "ip_src_addr":"192.168.1.8", "ip_src_port": 8001, "timestamp":10, "is_alert":false}
+   * ]
+   */
+  @Multiline
+  public static String snortData;
+
+  /**
+   * {
+   * "indices": ["bro", "snort"],
+   * "query": "*",
+   * "from": 0,
+   * "size": 10,
+   * "sort": [
+   *   {
+   *     "field": "timestamp",
+   *     "sortOrder": "desc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String allQuery;
+
+  /**
+   * {
+   * "indices": ["bro", "snort"],
+   * "query": "ip_src_addr:192.168.1.1",
+   * "from": 0,
+   * "size": 10,
+   * "sort": [
+   *   {
+   *     "field": "timestamp",
+   *     "sortOrder": "desc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String filterQuery;
+
+  /**
+   * {
+   * "indices": ["bro", "snort"],
+   * "query": "*",
+   * "from": 0,
+   * "size": 10,
+   * "sort": [
+   *   {
+   *     "field": "ip_src_port",
+   *     "sortOrder": "asc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String sortQuery;
+
+  /**
+   * {
+   * "indices": ["bro", "snort"],
+   * "query": "*",
+   * "from": 4,
+   * "size": 3,
+   * "sort": [
+   *   {
+   *     "field": "timestamp",
+   *     "sortOrder": "desc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String paginationQuery;
+
+  /**
+   * {
+   * "indices": ["bro"],
+   * "query": "*",
+   * "from": 0,
+   * "size": 10,
+   * "sort": [
+   *   {
+   *     "field": "timestamp",
+   *     "sortOrder": "desc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String indexQuery;
+
+  /**
+   * {
+   * "indices": ["bro", "snort"],
+   * "query": "*",
+   * "from": 0,
+   * "size": 101,
+   * "sort": [
+   *   {
+   *     "field": "timestamp",
+   *     "sortOrder": "desc"
+   *   }
+   * ]
+   * }
+   */
+  @Multiline
+  public static String exceededMaxResultsQuery;
+
+  protected IndexDao dao;
+  protected InMemoryComponent indexComponent;
+
+  @Before
+  public void setup() throws Exception {
+    indexComponent = startIndex();
+    loadTestData();
+    dao = createDao();
+  }
+
+  @Test
+  public void test() throws Exception {
+    //All Query Testcase
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(allQuery, SearchRequest.class);
+      SearchResponse response = dao.search(request);
+      Assert.assertEquals(10, response.getTotal());
+      List<SearchResult> results = response.getResults();
+      for(int i = 0;i < 5;++i) {
+        Assert.assertEquals("snort", results.get(i).getSource().get("source:type"));
+        Assert.assertEquals(10-i, results.get(i).getSource().get("timestamp"));
+      }
+      for(int i = 5;i < 10;++i) {
+        Assert.assertEquals("bro", results.get(i).getSource().get("source:type"));
+        Assert.assertEquals(10-i, results.get(i).getSource().get("timestamp"));
+      }
+    }
+    //Filter test case
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(filterQuery, SearchRequest.class);
+      SearchResponse response = dao.search(request);
+      Assert.assertEquals(3, response.getTotal());
+      List<SearchResult> results = response.getResults();
+      Assert.assertEquals("snort", results.get(0).getSource().get("source:type"));
+      Assert.assertEquals(9, results.get(0).getSource().get("timestamp"));
+      Assert.assertEquals("snort", results.get(1).getSource().get("source:type"));
+      Assert.assertEquals(7, results.get(1).getSource().get("timestamp"));
+      Assert.assertEquals("bro", results.get(2).getSource().get("source:type"));
+      Assert.assertEquals(1, results.get(2).getSource().get("timestamp"));
+    }
+    //Sort test case
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(sortQuery, SearchRequest.class);
+      SearchResponse response = dao.search(request);
+      Assert.assertEquals(10, response.getTotal());
+      List<SearchResult> results = response.getResults();
+      for(int i = 8001;i < 8011;++i) {
+        Assert.assertEquals(i, results.get(i-8001).getSource().get("ip_src_port"));
+      }
+    }
+    //pagination test case
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(paginationQuery, SearchRequest.class);
+      SearchResponse response = dao.search(request);
+      Assert.assertEquals(10, response.getTotal());
+      List<SearchResult> results = response.getResults();
+      Assert.assertEquals(3, results.size());
+      Assert.assertEquals("snort", results.get(0).getSource().get("source:type"));
+      Assert.assertEquals(6, results.get(0).getSource().get("timestamp"));
+      Assert.assertEquals("bro", results.get(1).getSource().get("source:type"));
+      Assert.assertEquals(5, results.get(1).getSource().get("timestamp"));
+      Assert.assertEquals("bro", results.get(2).getSource().get("source:type"));
+      Assert.assertEquals(4, results.get(2).getSource().get("timestamp"));
+    }
+    //Index query
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(indexQuery, SearchRequest.class);
+      SearchResponse response = dao.search(request);
+      Assert.assertEquals(5, response.getTotal());
+      List<SearchResult> results = response.getResults();
+      for(int i = 5,j=0;i > 0;i--,j++) {
+        Assert.assertEquals("bro", results.get(j).getSource().get("source:type"));
+        Assert.assertEquals(i, results.get(j).getSource().get("timestamp"));
+      }
+    }
+    //Exceeded maximum results query
+    {
+      SearchRequest request = JSONUtils.INSTANCE.load(exceededMaxResultsQuery, SearchRequest.class);
+      try {
+        dao.search(request);
+        Assert.fail("Exception expected, but did not come.");
+      }
+      catch(InvalidSearchException ise) {
+        Assert.assertEquals("Search result size must be less than 100", ise.getMessage());
+      }
+    }
+  }
+
+  @After
+  public void stop() throws Exception {
+    indexComponent.stop();
+  }
+
+  protected abstract IndexDao createDao() throws Exception;
+  protected abstract InMemoryComponent startIndex() throws Exception;
+  protected abstract void loadTestData() throws Exception;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <global_maven_version>[3.3.1,)</global_maven_version>
         <global_kryo_version>3.0.3</global_kryo_version>
         <global_kryo_serializers_version>0.38</global_kryo_serializers_version>
+        <global_reflections_version>0.9.10</global_reflections_version>
         <argLine></argLine>
     </properties>
 


### PR DESCRIPTION
This should provide an indirection layer where we can implement a DAO for interaction with the indices and have the implementations live in `metron-elasticsearch` and `metron-solr` until they're specified at runtime.

This is donated without requirement of attribution.