### PR TITLE
Migrating field name transformer to the REST config rather than hard coding in the HBaseDao

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/MetronRestConstants.java
@@ -60,6 +60,7 @@ public class MetronRestConstants {
   public static final String INDEX_DAO_IMPL = "index.dao.impl";
   public static final String INDEX_HBASE_TABLE_PROVIDER_IMPL = "index.hbase.provider";
   public static final String INDEX_WRITER_NAME = "index.writer.name";
+  public static final String INDEX_FIELD_CONVERTER_NAME = "index.fieldNameConverter.impl";
 
   public static final String META_DAO_IMPL = "meta.dao.impl";
   public static final String META_DAO_SORT = "meta.dao.sort";

--- a/metron-interface/metron-rest/src/main/resources/application-test.yml
+++ b/metron-interface/metron-rest/src/main/resources/application-test.yml
@@ -51,7 +51,8 @@ index:
   hbase:
   # HBase is provided via a mock provider, so no actual HBase infrastructure is started.
      provider: org.apache.metron.hbase.mock.MockHBaseTableProvider
-
+  fieldNameConverter:
+     impl: org.apache.metron.indexing.converter.DotToColonFieldNameConverter
 meta:
   dao:
   # By default, we use the InMemoryMetaAlertDao for our tests

--- a/metron-interface/metron-rest/src/main/resources/application.yml
+++ b/metron-interface/metron-rest/src/main/resources/application.yml
@@ -56,6 +56,8 @@ index:
   writer:
   # Used to retrieve the index names from the sensor index configurations.  Should be either 'elasticsearch' or 'solr'.
     name: elasticsearch
+  fieldNameConverter:
+    impl: org.apache.metron.indexing.converter.DotToColonFieldNameConverter
 
 meta:
   dao:

--- a/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/ElasticsearchWriter.java
+++ b/metron-platform/metron-elasticsearch/src/main/java/org/apache/metron/elasticsearch/writer/ElasticsearchWriter.java
@@ -23,6 +23,7 @@ import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.common.writer.BulkMessageWriter;
 import org.apache.metron.common.writer.BulkWriterResponse;
 import org.apache.metron.elasticsearch.utils.ElasticsearchUtils;
+import org.apache.metron.indexing.converter.DotToColonFieldNameConverter;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -47,7 +48,7 @@ public class ElasticsearchWriter implements BulkMessageWriter<JSONObject>, Seria
   private transient TransportClient client;
   private SimpleDateFormat dateFormat;
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchWriter.class);
-  private FieldNameConverter fieldNameConverter = new ElasticsearchFieldNameConverter();
+  private FieldNameConverter fieldNameConverter = new DotToColonFieldNameConverter();
 
   public ElasticsearchWriter withOptionalSettings(Map<String, String> optionalSettings) {
     this.optionalSettings = optionalSettings;

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
@@ -19,7 +19,7 @@ package org.apache.metron.elasticsearch.integration;
 
 import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.elasticsearch.integration.components.ElasticSearchComponent;
-import org.apache.metron.elasticsearch.writer.ElasticsearchFieldNameConverter;
+import org.apache.metron.indexing.converter.DotToColonFieldNameConverter;
 import org.apache.metron.indexing.integration.IndexingIntegrationTest;
 import org.apache.metron.integration.ComponentRunner;
 import org.apache.metron.integration.InMemoryComponent;
@@ -41,7 +41,7 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
   private String indexDir = "target/elasticsearch";
   private String dateFormat = "yyyy.MM.dd.HH";
   private String index = "yaf_index_" + new SimpleDateFormat(dateFormat).format(new Date());
-  private FieldNameConverter fieldNameConverter = new ElasticsearchFieldNameConverter();
+  private FieldNameConverter fieldNameConverter = new DotToColonFieldNameConverter();
 
   @Override
   public FieldNameConverter getFieldNameConverter() {

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/converter/DefaultFieldNameConverter.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/converter/DefaultFieldNameConverter.java
@@ -15,18 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.metron.indexing.converter;
 
-package org.apache.metron.elasticsearch.writer;
+import org.apache.metron.common.interfaces.FieldNameConverter;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
-public class ElasticsearchFieldNameConverterTest {
-
-    @Test
-    public void convert() throws Exception {
-        assertEquals("testfield:with:colons",new ElasticsearchFieldNameConverter().convert("testfield.with.colons"));
-    }
-
+public class DefaultFieldNameConverter implements FieldNameConverter {
+  @Override
+  public String convert(String originalField) {
+    return originalField;
+  }
 }

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/converter/DotToColonFieldNameConverter.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/converter/DotToColonFieldNameConverter.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.indexing.converter;
+
+import org.apache.metron.common.interfaces.FieldNameConverter;
+import java.io.Serializable;
+
+public class DotToColonFieldNameConverter implements FieldNameConverter, Serializable {
+
+    private static final long serialVersionUID = -3126840090749760299L;
+
+    @Override
+    public String convert(String originalField) {
+        return originalField.replace(".",":");
+    }
+
+}

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/AccessConfig.java
@@ -17,6 +17,8 @@
  */
 package org.apache.metron.indexing.dao;
 
+import org.apache.metron.common.interfaces.FieldNameConverter;
+import org.apache.metron.common.utils.ReflectionUtils;
 import org.apache.metron.hbase.TableProvider;
 
 import java.util.HashMap;
@@ -24,11 +26,24 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class AccessConfig {
+  private FieldNameConverter fieldNameConverter;
   private Integer maxSearchResults;
   private Integer maxSearchGroups;
   private Supplier<Map<String, Object>> globalConfigSupplier;
   private Map<String, String> optionalSettings = new HashMap<>();
   private TableProvider tableProvider = null;
+
+  public FieldNameConverter getFieldNameConverter() {
+    return fieldNameConverter;
+  }
+
+  public void setFieldNameConverter(FieldNameConverter fieldNameConverter) {
+    this.fieldNameConverter = fieldNameConverter;
+  }
+
+  public void setFieldNameConverter(String fieldNameConverterClazz) {
+    this.fieldNameConverter = ReflectionUtils.createInstance(fieldNameConverterClazz);
+  }
 
   /**
    * A supplier which will return the current global config.

--- a/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/HBaseDao.java
+++ b/metron-platform/metron-indexing/src/main/java/org/apache/metron/indexing/dao/HBaseDao.java
@@ -35,7 +35,9 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metron.common.Constants;
+import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.indexing.converter.DefaultFieldNameConverter;
 import org.apache.metron.indexing.dao.search.FieldType;
 import org.apache.metron.indexing.dao.search.GroupRequest;
 import org.apache.metron.indexing.dao.search.GroupResponse;
@@ -43,6 +45,8 @@ import org.apache.metron.indexing.dao.search.InvalidSearchException;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
 import org.apache.metron.indexing.dao.update.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The HBaseDao is an index dao which only supports the following actions:
@@ -56,7 +60,8 @@ import org.apache.metron.indexing.dao.update.Document;
  *
  */
 public class HBaseDao implements IndexDao {
-  public static final String SOURCE_TYPE = Constants.SENSOR_TYPE.replace('.', ':');
+  private static final Logger LOG = LoggerFactory.getLogger(HBaseDao.class);
+  public String SOURCE_TYPE;
   public static String HBASE_TABLE = "update.hbase.table";
   public static String HBASE_CF = "update.hbase.cf";
   private HTableInterface tableInterface;
@@ -95,6 +100,15 @@ public class HBaseDao implements IndexDao {
       } catch (IOException e) {
         throw new IllegalStateException("Unable to initialize HBaseDao: " + e.getMessage(), e);
       }
+      FieldNameConverter fieldNameConverter = null;
+      if(config.getFieldNameConverter() == null) {
+        LOG.warn("Unable to find the field name transformer.  Using default field name transformer instead.");
+        fieldNameConverter = new DefaultFieldNameConverter();
+      }
+      else {
+        fieldNameConverter = config.getFieldNameConverter();
+      }
+      SOURCE_TYPE = fieldNameConverter.convert(Constants.SENSOR_TYPE);
     }
   }
 

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/converter/DotToColonFieldNameConverterTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/converter/DotToColonFieldNameConverterTest.java
@@ -15,18 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.elasticsearch.writer;
 
-import org.apache.metron.common.interfaces.FieldNameConverter;
-import java.io.Serializable;
+package org.apache.metron.indexing.converter;
 
-public class ElasticsearchFieldNameConverter implements FieldNameConverter, Serializable {
+import org.apache.metron.indexing.converter.DotToColonFieldNameConverter;
+import org.junit.Test;
 
-    private static final long serialVersionUID = -3126840090749760299L;
+import static org.junit.Assert.*;
 
-    @Override
-    public String convert(String originalField) {
-        return originalField.replace(".",":");
+public class DotToColonFieldNameConverterTest {
+
+    @Test
+    public void convert() throws Exception {
+        assertEquals("testfield:with:colons",new DotToColonFieldNameConverter().convert("testfield.with.colons"));
     }
 
 }

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/HBaseDaoIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.metron.hbase.mock.MockHBaseTableProvider;
+import org.apache.metron.indexing.converter.DotToColonFieldNameConverter;
 import org.apache.metron.indexing.dao.AccessConfig;
 import org.apache.metron.indexing.dao.HBaseDao;
 import org.apache.metron.indexing.dao.IndexDao;
@@ -57,6 +58,7 @@ public class HBaseDaoIntegrationTest {
       put(HBASE_TABLE, TABLE_NAME);
       put(HBASE_CF, COLUMN_FAMILY);
     }});
+    accessConfig.setFieldNameConverter(new DotToColonFieldNameConverter());
     MockHBaseTableProvider.addToCache(TABLE_NAME, COLUMN_FAMILY);
     accessConfig.setTableProvider(new MockHBaseTableProvider());
 


### PR DESCRIPTION
As a potential solution to Justin's issue (which I share) of coupling the HBaseDao with the Elasticsearch specific field name transformation logic, I propose that we do something like this:
* Migrate the FieldNameConverter as a field in the REST config
* Make the IndexDao take the FieldNameConverter in the AccessConfig
* Have the HBaseDao use the parameterized field name converter to transform `source.type` to the appropriate field.
